### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/thunder-client.ts
+++ b/src/thunder-client.ts
@@ -11,7 +11,7 @@ function normalizeCurlInputForWindows(curlInput: string): string {
     return curlInput.replace(
         /(-d|--data(?:-raw)?)\s+(['"])([\s\S]*?)\2/g,
         (_, flag: string, _quote: string, rawBody: string) => {
-            const escapedBody = rawBody.replace(/"/g, '\\"');
+            const escapedBody = rawBody.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
             return `${flag} "${escapedBody}"`;
         }
     );


### PR DESCRIPTION
Potential fix for [https://github.com/thunderclient/thunderclient-mcp/security/code-scanning/1](https://github.com/thunderclient/thunderclient-mcp/security/code-scanning/1)

To fix the issue, we need to ensure that backslashes in the `rawBody` are properly escaped. This can be achieved by adding a replacement step to escape backslashes (`\`) before escaping double quotes. Specifically:
1. Replace all backslashes (`\`) with double backslashes (`\\`).
2. Then replace all double quotes (`"`) with escaped double quotes (`\"`).

This ensures that the resulting string is properly escaped for use in a shell command. The fix will involve modifying the `normalizeCurlInputForWindows` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
